### PR TITLE
Add audio using serial mp3 library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,11 @@ lib_deps =
 build_flags = -DUSE_AUDIO
 lib_deps = dfrobot/DFRobotDFPlayerMini@^1.0.3
 
+[audio_TD5580A]
+build_flags = -DUSE_AUDIO -DUSE_SERIAL_MP3
+lib_deps = 
+	nhluan37/SerialMP3@^1.0.0
+
 [audio_powerbroker]
 build_flags= -DUSE_AUDIO -DUSE_AUDIO_CARL -DUSE_POWERBROKER_MP3_DRIVER
 lib_deps =
@@ -63,6 +68,15 @@ build_flags = ${audio.build_flags}
 lib_deps =
 	${common.lib_deps}
 	${audio.lib_deps}
+	${esp8266.lib_deps}
+
+[env:esp8266_d1_mini_TD5580A]
+board = d1_mini
+extends = esp8266
+build_flags = ${audio_TD5580A.build_flags}
+lib_deps = 
+	${common.lib_deps}
+	${audio_TD5580A.lib_deps}
 	${esp8266.lib_deps}
 
 [env:esp8266_d1_mini_noaudio]

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -4,9 +4,7 @@
 #include <Arduino.h>
 #include "Settings.h"
 #include <SoftwareSerial.h>
-#ifdef USE_AUDIO
 #include <DFRobotDFPlayerMini.h>
-#endif
 
 #include "Pins.h"
 
@@ -17,44 +15,33 @@ public:
   }
 
   void Begin() {
-#ifdef USE_AUDIO
     pinMode(BUSY, INPUT);
+
     softwareSerial.begin(9600);
     myDFPlayer.begin(softwareSerial);
     delay(100);
     myDFPlayer.volume(settings.audioVolume);
-#endif
   }
 
   void PlaySound(uint8_t folder, uint8_t file) {
-#ifdef USE_AUDIO
     myDFPlayer.playFolder(folder, file);
-#endif
   }
 
   void Stop() {
-#ifdef USE_AUDIO
     myDFPlayer.stop();
-#endif
   }
 
   bool IsPlayingAudio() {
-#ifdef USE_AUDIO
 #ifdef LEGACY
     return analogRead(AUDIO_BUSY) < 0XFF;
 #else
     return digitalRead(AUDIO_BUSY) == LOW;
-#endif
-#else
-    return false;
-#endif
   }
+
 private:
   Settings &settings;
   SoftwareSerial &softwareSerial;
-#ifdef USE_AUDIO
   DFRobotDFPlayerMini myDFPlayer;
-#endif
 };
 
 #endif

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -36,6 +36,7 @@ public:
     return analogRead(AUDIO_BUSY) < 0XFF;
 #else
     return digitalRead(AUDIO_BUSY) == LOW;
+#endif
   }
 
 private:

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -15,7 +15,7 @@ public:
   }
 
   void Begin() {
-    pinMode(BUSY, INPUT);
+    pinMode(AUDIO_BUSY, INPUT);
 
     softwareSerial.begin(9600);
     myDFPlayer.begin(softwareSerial);

--- a/src/Audio_TD5580A.h
+++ b/src/Audio_TD5580A.h
@@ -35,6 +35,7 @@ public:
     return analogRead(AUDIO_BUSY) < 0XFF;
 #else
     return digitalRead(AUDIO_BUSY) == LOW;
+#endif
   }
 
 private:

--- a/src/Audio_TD5580A.h
+++ b/src/Audio_TD5580A.h
@@ -1,0 +1,45 @@
+#ifndef PT_AUDIO
+#define PT_AUDIO
+
+#include <Arduino.h>
+#include "Settings.h"
+#include <SerialMP3.h>
+
+#include "Pins.h"
+
+class Audio {
+public:
+  Audio(Settings &settings, uint8_t rx, uint8_t tx)
+    : settings(settings), mp3(rx, tx)
+    {
+    }
+
+  void Begin() {
+    pinMode(AUDIO_BUSY, INPUT);
+
+    mp3.init(); 
+    delay(100);
+    mp3.setVolume(settings.audioVolume);
+  }
+
+  void PlaySound(uint8_t folder, uint8_t file) {
+    mp3.playFolderFile(folder, file);
+  }
+
+  void Stop() {
+    mp3.stop();
+  }
+
+  bool IsPlayingAudio() {
+#ifdef LEGACY
+    return analogRead(AUDIO_BUSY) < 0XFF;
+#else
+    return digitalRead(AUDIO_BUSY) == LOW;
+  }
+
+private:
+  Settings &settings;
+  SerialMP3 mp3;
+};
+
+#endif

--- a/src/Audio_dummy.h
+++ b/src/Audio_dummy.h
@@ -1,0 +1,30 @@
+#ifndef PT_AUDIO
+#define PT_AUDIO
+
+#include <Arduino.h>
+#include "Settings.h"
+
+class Audio {
+public:
+  Audio(Settings &settings)
+    : settings(settings) {
+  }
+
+  void Begin() {
+  }
+
+  void PlaySound(uint8_t folder, uint8_t file) {
+  }
+
+  void Stop() {
+  }
+
+  bool IsPlayingAudio() {
+    return false;
+  }
+
+private:
+  Settings &settings;
+};
+
+#endif

--- a/src/PortalSentry.cpp
+++ b/src/PortalSentry.cpp
@@ -18,30 +18,29 @@ SoftwareSerial softwareSerial(AUDIO_RX, AUDIO_TX);
 // Why do I have to include this here? Servo.h otherwise found twice?
 #include <ESPAsyncWebServer.h>
 
-#ifdef USE_AUDIO_CARL
-#include "Audio_carl.h"
-#else
-#ifdef HARDWARE_V3
-#include "ESP32Audio.h"
-#else
-#include "Audio.h"
-#endif
-#endif
 #include "LEDs.h"
 #include "Sensors.h"
 #include "Servos.h"
 #include "Settings.h"
 
 Settings settings;
+
+#ifdef USE_AUDIO_CARL
+#include "Audio_carl.h"
+Audio audio(settings, softwareSerial);
+
+#elif HARDWARE_V3
+#include "ESP32Audio.h"
+Audio audio(settings);
+
+#else
+#include "Audio.h"
+Audio audio(settings, softwareSerial);
+#endif
+
 Sensors sensors(settings);
 Servos servos(settings, sensors);
 LEDs leds;
-
-#ifdef HARDWARE_V3
-Audio audio(settings);
-#else
-Audio audio(settings, softwareSerial);
-#endif
 
 #include "Routines.h"
 #include "StateBehaviour.h"

--- a/src/PortalSentry.cpp
+++ b/src/PortalSentry.cpp
@@ -33,6 +33,10 @@ Audio audio(settings, softwareSerial);
 #include "ESP32Audio.h"
 Audio audio(settings);
 
+#elif USE_SERIAL_MP3
+#include "Audio_TD5580A.h"
+Audio audio(settings, AUDIO_RX, AUDIO_TX);
+
 #elif USE_AUDIO
 #include "Audio.h"
 Audio audio(settings, softwareSerial);

--- a/src/PortalSentry.cpp
+++ b/src/PortalSentry.cpp
@@ -33,9 +33,13 @@ Audio audio(settings, softwareSerial);
 #include "ESP32Audio.h"
 Audio audio(settings);
 
-#else
+#elif USE_AUDIO
 #include "Audio.h"
 Audio audio(settings, softwareSerial);
+
+#else
+#include "Audio_dummy.h"
+Audio audio(settings);
 #endif
 
 Sensors sensors(settings);


### PR DESCRIPTION
Based on https://www.youtube.com/watch?v=8nHDoSQJDuk 

The serial mp3 library seems to be more consistently playing audio with my dfplayer with TD5580A chip.

I've also changed the code a bit to make adding more audio implementations easier and fixed a potential bug with the busy pin.