### PR TITLE
Bump SerialMP3 and set build flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ lib_deps = dfrobot/DFRobotDFPlayerMini@^1.0.3
 [audio_TD5580A]
 build_flags = -DUSE_AUDIO -DUSE_SERIAL_MP3 -DNO_SERIALMP3_DELAY
 lib_deps =
-	nhluan37/SerialMP3@^1.1.0
+	nhluan37/SerialMP3@1.1.0
 
 [audio_powerbroker]
 build_flags= -DUSE_AUDIO -DUSE_AUDIO_CARL -DUSE_POWERBROKER_MP3_DRIVER

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,9 +25,9 @@ build_flags = -DUSE_AUDIO
 lib_deps = dfrobot/DFRobotDFPlayerMini@^1.0.3
 
 [audio_TD5580A]
-build_flags = -DUSE_AUDIO -DUSE_SERIAL_MP3
-lib_deps = 
-	nhluan37/SerialMP3@^1.0.0
+build_flags = -DUSE_AUDIO -DUSE_SERIAL_MP3 -DNO_SERIALMP3_DELAY
+lib_deps =
+	nhluan37/SerialMP3@^1.1.0
 
 [audio_powerbroker]
 build_flags= -DUSE_AUDIO -DUSE_AUDIO_CARL -DUSE_POWERBROKER_MP3_DRIVER


### PR DESCRIPTION
I've updated the serial mp3 library to allow turning off the delay after sending a command https://github.com/nhluan37/SerialMP3/pull/1
This makes sure the gun sound and lights are in sync when using the esp8266_d1_mini_TD5580A build