### PR TITLE
Normalized the name of the "Pins.h" header - made it capitalized everywhere

### DIFF
--- a/src/ESP32Audio.h
+++ b/src/ESP32Audio.h
@@ -9,7 +9,6 @@
 #include <AudioFileSourceLittleFS.h>
 #include <AudioGeneratorMP3.h>
 #include <AudioOutputI2S.h>
-#include "pins.h"
 
 class Audio {
 public:

--- a/src/LEDs.h
+++ b/src/LEDs.h
@@ -2,7 +2,7 @@
 #define PT_LEDS
 
 #include <FastLED.h>
-#include "pins.h"
+#include "Pins.h"
 
 #define NUM_LEDS 8
 

--- a/src/PortalSentry.cpp
+++ b/src/PortalSentry.cpp
@@ -1,6 +1,6 @@
 // General
 #include <Arduino.h>
-#include "pins.h"
+#include "Pins.h"
 
 #ifdef LEGACY
 #include <Adafruit_PWMServoDriver.h>

--- a/src/Sensors.h
+++ b/src/Sensors.h
@@ -5,7 +5,7 @@
 #include "Settings.h"
 #include <Adafruit_ADXL345_U.h>
 #include <Adafruit_Sensor.h>
-#include "pins.h"
+#include "Pins.h"
 
 #define MEASUREMENTS 10
 

--- a/src/Servos.h
+++ b/src/Servos.h
@@ -9,7 +9,7 @@
 #else
 #include <Servo.h>
 #endif
-#include "pins.h"
+#include "Pins.h"
 
 // Tweak these according to servo speed
 #define CLOSE_STOP_DELAY 100


### PR DESCRIPTION
The name of the header was spelled differently in different source files - sometimes it was included as "pins.h", sometimes as "Pins.h". It's not a problem on Windows, but it fails to compile on Linux (and I guess it would fail on Mac as well.).