### PR TITLE
fix wrong array size

### DIFF
--- a/src/PortalServer.h
+++ b/src/PortalServer.h
@@ -396,7 +396,7 @@ void StartServer() {
     Serial.println(WiFi.localIP());
 #ifdef HARDWARE_V3
     char filename[256];
-    for (int folder = 1; folder <= sizeof(sounds_number); folder++) {
+    for (int folder = 1; folder <= sizeof(sounds_number) / sizeof(sounds_number[0]); folder++) {
       snprintf(filename, 255, "/%02i", folder);
       LittleFS.mkdir(filename);
       for (int filenum = 1; filenum <= sounds_number[folder-1]; filenum++) {


### PR DESCRIPTION
sizeof(sounds_number) was returning 8 (pointer size) instead of 9 (array length), causing the loop to skip the last sound folder. Fixed by using the standard sizeof(arr) / sizeof(arr[0]) idiom which always gives the correct element count regardless of type or platform.