### PR TITLE
Add destructor to Audio class to properly release I2S and MP3 resources

### DIFF
--- a/src/ESP32Audio.h
+++ b/src/ESP32Audio.h
@@ -45,6 +45,20 @@ public:
     return mp3 && mp3->isRunning();
   }
 
+  ~Audio() {
+    if (mp3) {
+      if (mp3->isRunning())
+        mp3->stop();
+      delete mp3;
+      mp3 = nullptr;
+    }
+    cleanupFile();
+    if (out) {
+      delete out;
+      out = nullptr;
+    }
+  }
+
   void Loop() {
     if (mp3 && mp3->isRunning()) {
       if (!mp3->loop()) {


### PR DESCRIPTION
out (AudioOutputI2S) and mp3 (AudioGeneratorMP3) were allocated in Begin() but never freed. Added ~Audio() that stops playback if running, deletes both objects, and cleans up the file handle via the existing cleanupFile().