### PR TITLE
Replace heap-allocated WiFiClientSecure global with static local

### DIFF
--- a/src/ESP32Downloader.cpp
+++ b/src/ESP32Downloader.cpp
@@ -4,25 +4,25 @@
 #include <LittleFS.h>
 #include "config.h"
 
-#include <WiFiClient.h>
-WiFiClient* wifiClient;
+#include <WiFiClientSecure.h>
 
 #define PREFIX "https://joranderaaff.nl/portal-sentry/audio/english"
 
 void downloadFile(const char* urlPath, const char* filePath) {
-  String fullUrl = String(PREFIX) + String(urlPath);
-  if (wifiClient == NULL) {
-    WiFiClientSecure* sslclient = new WiFiClientSecure();
-    sslclient->setInsecure();
-    wifiClient = sslclient;
+  static WiFiClientSecure sslclient;
+  static bool initialized = false;
+  if (!initialized) {
+    sslclient.setInsecure();
+    initialized = true;
   }
-  
+
+  String fullUrl = String(PREFIX) + String(urlPath);
   Serial.print("Requesting: ");
   Serial.println(fullUrl);
 
   // Start the request to download the file
   HTTPClient http;
-  http.begin(*wifiClient, fullUrl);
+  http.begin(sslclient, fullUrl);
   int statusCode = http.GET();
 
   if (statusCode == 200) {
@@ -32,6 +32,7 @@ void downloadFile(const char* urlPath, const char* filePath) {
     File file = LittleFS.open(filePath, FILE_WRITE);
     if (!file) {
       Serial.println("Failed to open file for writing");
+      http.end();
       return;
     }
 
@@ -60,6 +61,11 @@ void downloadFile(const char* urlPath, const char* filePath) {
       }
       delay(1);
     }
+
+    file.close();
   }
+
+  http.end();
 }
 #endif
+


### PR DESCRIPTION
The global WiFiClient* pointer was never freed and relied on a transitive include for WiFiClientSecure.h. Replaced with a static local instance that is initialized once on first call, removing the global, the manual new/delete, and the incorrect WiFiClient.h include.